### PR TITLE
Fix two copy-paste errors in exercises and one in a definition

### DIFF
--- a/tex/CT4P.tex
+++ b/tex/CT4P.tex
@@ -1098,7 +1098,7 @@ In this section, we discuss special objects in a category.
 \end{exer}
 
 \begin{exer}
-  Does the category $A \to B$ have an initial object?
+  Does the category $A \to B$ have products?
 \end{exer}
 
 \begin{exer}

--- a/tex/CT4P.tex
+++ b/tex/CT4P.tex
@@ -1145,12 +1145,12 @@ In this section, we discuss special objects in a category.
       B \ar[l, "\inr"'] \ar[ld, "i_r"]
       \\
       &
-      Q %\ar[ld, "q_1"'] \ar[rd, "q_2"] \ar[d, "f"]
+      D %\ar[ld, "q_1"'] \ar[rd, "q_2"] \ar[d, "f"]
       &
       \\
     \end{tikzcd}
   \]
-  If $A$ and $B$ have a specified coproduct $(C,\inl : A \to C,\inr : B \to C)$, then the object $P$ is often called $A + B$.
+  If $A$ and $B$ have a specified coproduct $(C,\inl : A \to C,\inr : B \to C)$, then the object $C$ is often called $A + B$.
 \end{dfn}
 
 \begin{exer}

--- a/tex/CT4P.tex
+++ b/tex/CT4P.tex
@@ -1028,7 +1028,7 @@ In this section, we discuss special objects in a category.
 \end{exer}
 
 \begin{exer}
-  Does the category $A \to B$ have an terminal object?
+  Does the category $A \to B$ have a terminal object?
 \end{exer}
 
 \begin{exer}

--- a/tex/CT4P.tex
+++ b/tex/CT4P.tex
@@ -1028,7 +1028,7 @@ In this section, we discuss special objects in a category.
 \end{exer}
 
 \begin{exer}
-  Does the category $A \to B$ have an initial object?
+  Does the category $A \to B$ have an terminal object?
 \end{exer}
 
 \begin{exer}


### PR DESCRIPTION
Two exercises (in the exercise set about the terminal object and products) still asked about the initial object.
The definition of the coproduct was copied from the definition of the product, but then replaced `P` by `C` and `Q` by `D` in some places, but not in others.
This pull request fixes both of these.