### PR TITLE
Fix typos 

### DIFF
--- a/tex/CT4P.tex
+++ b/tex/CT4P.tex
@@ -439,14 +439,14 @@ We say that such a square \textbf{commutes} if $\co{f_1}{g_1} = \co{f_2}{g_2}$.
 $$g \circ f : X\to Z: x\mapsto g(f(x)).$$
 \end{itemize}
 \end{exa}
-\begin{lemma} The data of $\SET$ satisfies the properties of a category, hence $\SET$ is indeed a category.
+\begin{lemma} The data of $\SET$ satisfies the properties of a category; hence $\SET$ is indeed a category.
 \begin{proof}
-We first show that the left unit law holds. Let $X,Y\in \mathbf{Set}$ be sets and $f\in \CHom \SET X Y$ a function. We have to show that $\Id[X] \Comp f = f$, hence it suffices to show that they pointwise equal which holds by the following calculation:
+We first show that the left unit law holds. Let $X,Y\in \mathbf{Set}$ be sets and $f\in \CHom \SET X Y$ a function. We have to show that $\Id[X] \Comp f = f$; hence it suffices to show that they are pointwise equal, which holds by the following calculation:
 \[
 \forall x\in X: (f\circ \Id[X])(x) = f\left(\Id[X](x)\right) = f(x),
 \]
 where the first (resp. second) equality holds by definition of the composition (resp. identity morphism).\\
-That the right unit law holds is analogous. To show that the associator law holds, let $X,Y,Z,W\in\mathbf{Set}$ and $f\in \CHom \SET X Y, g\in \CHom \SET Y Z$ and $h\in \CHom \SET Z W$. We have to show $h\circ (g\circ f) = (h\circ g)\circ f$, hence it suffices again to show that they are pointwise equal which holds by the following calculation:
+That the right unit law holds is analogous. To show that the associator law holds, let $X,Y,Z,W\in\mathbf{Set}$ and $f\in \CHom \SET X Y, g\in \CHom \SET Y Z$ and $h\in \CHom \SET Z W$. We have to show $h\circ (g\circ f) = (h\circ g)\circ f$; hence it suffices again to show that they are pointwise equal which holds by the following calculation:
 \begin{eqnarray*}
 \forall x\in X: \left(h\circ (g\circ f)\right)(x) &=& h\left((g\circ f)(x)\right), \\ 
 	&=& h(g(f(x))),\\ 
@@ -494,7 +494,7 @@ axiom funext_nondep : ∀ {A B : Type} (f g : A → B),
   We repeat the definitions of \cref{exa:lean-cat} in Haskell instead of Lean.
   Does this data satisfies the axioms of a category?
 
-  Due to Haskell allowing for the |undefined| value in each type, the situation is slighly more complicated; consider the following two functions:
+  Due to Haskell allowing for the |undefined| value in each type, the situation is slightly more complicated; consider the following two functions:
 \begin{lstlisting}
 undef1 :: a -> a
 undef1 = undefined
@@ -543,7 +543,7 @@ Recall that a \textit{preordered set} $(X,\leq)$ consists of a set $X$ together 
 \item The objects are the elements of $X$.
 \item Let $x,y \in X$ be elements. The hom-set $\Hom x y$ consists of a unique element if $x\leq y$ and is empty otherwise.
 \item  We need an identity morphism for each $x\in X$.
-  By reflexitivity (i.e., $x\leq x$), we have that $\Hom x x$ consists of a unique element, which we take to be the identity.
+  By reflexivity (i.e., $x\leq x$), we have that $\Hom x x$ consists of a unique element, which we take to be the identity.
 \item We need to define for each $x,y,z\in X$, a composition operator:
 \[
 \Hom y z \to \Hom x y \to \Hom x z.
@@ -554,7 +554,7 @@ But then, by transitivity (i.e. if $x\leq y$ and $y\leq z$, then $x\leq z$), we 
 %
 We are now going to show that the axioms of a category holds.
 To show the right unit law, we have to show that for each $x,y\in X$ and $f\in \Hom x y$, we have $\co{\Id[x]}{f} = f$.
-This indeed holds since every hom-set has a unique element, but both $\co{\Id[x]}{f}$ and $f$ live in the same hom-set, hence they must be equal.
+This indeed holds since every hom-set has a unique element, but both $\co{\Id[x]}{f}$ and $f$ live in the same hom-set; hence they must be equal.
 The proof that left unit law and associator law hold are analogous.
 \end{exa}
 
@@ -850,7 +850,7 @@ Show that the only isomorphisms in $\mathcal{G}$ are the identity morphisms (i.e
 
 
 \begin{dfn}[Section, Retraction]
-  A pair $(s,r)$ of morphisms $s : a \to b$ and $r : b \to a$ in $\CC$ is called a \textbf{section-retraction pair} if $\co{s}{r} = \Id[b]$.
+  A pair $(s,r)$ of morphisms $s : a \to b$ and $r : b \to a$ in $\CC$ is called a \textbf{section-retraction pair} if $\co{s}{r} = \Id[a]$.
 
   In such a case, we call $s$ a section and $r$ a retraction.
 \end{dfn}
@@ -1248,7 +1248,7 @@ However, in more complicated categories---that is, in categories where the objec
 A & Q \arrow[l, "q_l"]  \arrow[r,swap, "q_r"] & B
 \end{tikzcd}
 \]
-\item The composition and identity is inherented from the structure of $\CC$.
+\item The composition and identity are inherited from the structure of $\CC$.
 \end{itemize}
 \end{exer}
 
@@ -1613,7 +1613,7 @@ Show that this indeed satisfies the naturality condition.
 \item An object is a functor $F:\CC\to\DD$.
 \item A morphism from $F$ to $G$ is a natural transformation $\NatTrans{\alpha}{F}{G}$.
 \item The identity morphism on $F$ is given by the identity natural transformation $\Id[F]$ defined in \cref{dfn:nattrans_id}.
-\item The composition of $F$ and $G$ is given by the composition $\co{\alpha}{\beta}$ defined in \cref{dfn:nattrans_comp}.
+\item The composition of $\alpha$ and $\beta$ is given by the composition $\co{\alpha}{\beta}$ defined in \cref{dfn:nattrans_comp}.
 \end{itemize}
 \end{dfn}
 
@@ -1637,7 +1637,7 @@ Hint: Write the equality as a (not-known commutative) square.
 \end{exer}
 
 \subsection{Exercises}
-\begin{exer} Let $(M,m,e)$ be a monoid and let $\MON(M,m,e)$ be its corresponding category. Recall from \cref{ex:monoid_functors} that a functor from $\mathcal{M}$ to $\SET$ is a set $X$ together with an action of $M$ on $X$, i.e. a function $\mu: M\times X\to X$ such that 
+\begin{exer} Let $(M,m,e)$ be a monoid and let $\MON(M,m,e)$ be its corresponding category. Recall from \cref{ex:monoid_functors} that a functor from $\MON(M,m,e)$ to $\SET$ is a set $X$ together with an action of $M$ on $X$, i.e. a function $\mu: M\times X\to X$ such that 
 \[
 \forall x\in X: \mu(e,x) = x, \quad \forall n_1,n_2\in M, x\in X: \mu(n_1, \mu(n_2,x)) = \mu(m(n_1,n_2), x).
 \]
@@ -1651,7 +1651,7 @@ Characterize the natural transformations between $M$-sets.
 \subsection{Equivalence of categories}
 Recall that objects $X,Y\in\Ob{\CC}$ are isomorphic if there exist morphisms $f\in\CHom{C}{X}{Y}$ and $g\in\CHom{C}{Y}{X}$ such that $\co{f}{g} = \Id[X]$ and $\co{g}{f} = \Id[Y]$. So in particular we have the notion of an isomorphism in the category $\CAT$ of categories. Spelled out, this means categories $\CC$ and $\DD$ are isomorphic if there exist functors $F:\CC\to\DD$ and $G:\CC\to\DD$ such that $\co{F}{G}= \Id[\CC]$ and $\co{G}{F} = \Id[\DD]$.\\
 However, the following exercise shows that isomorphism of categories is not the correct notion of \textit{equivalence/sameness} between categories:\\
-Let $\FINSET$ be the category whose objects are given by finite sets and whose morphisms are given by functions\footnote{Notice that the objects of $\FINSET$ form a subset of the objects of $\SET$, but given any two finite sets $X,Y in \Ob{\FINSET}$, we have $\CHom{FINSET}{X}{Y}$ = $\CHom{SET}{X}{Y}$. We say in this case that $\FINSET$ is a (full) subcategory of $\SET$.}. That this is a category follows since $\SET$ is a category.\\
+Let $\FINSET$ be the category whose objects are given by finite sets and whose morphisms are given by functions\footnote{Notice that the objects of $\FINSET$ form a subset of the objects of $\SET$, but given any two finite sets $X,Y \in \Ob{\FINSET}$, we have $\CHom{\FINSET}{X}{Y}$ = $\CHom{\SET}{X}{Y}$. We say in this case that $\FINSET$ is a (full) subcategory of $\SET$.}. That this is a category follows since $\SET$ is a category.\\
 Let $\Catb{FinOrd}$ be the category whose objects are given by sets of the form 
 \[
 [n] := \left\{0,1,\cdots,n-1\right\},
@@ -1696,19 +1696,19 @@ In order to show that $U$ is not an isomorphism, one can use the following lemma
 \begin{exer} Show that $U$ is not an isomorphism, i.e. state which part of an isomorphism fails and give a concrete example that it fails.
 \end{exer}
 
-\begin{rem} So the problem with $U$ (in the sense that it is not an isomorphism) is that multiple (finite) sets are mapped to the same set. For this reason, a good notion of equivalence between categories should not be injective on objects. Also, which is not clear from this example, we should also weaken the condition of $F$ being surjective on objects. Instead, we need that $F$ is \textbf{essentially surjective on objects}:
+\begin{rem} So, the problem with $U$ (in the sense that it is not an isomorphism) is that multiple (finite) sets are mapped to the same set. For this reason, a good notion of equivalence between categories should not be injective on objects. Also, which is not clear from this example, we should also weaken the condition of $F$ being surjective on objects. Instead, we need that $F$ is \textbf{essentially surjective on objects}:
 \[
 \forall Y\in\Ob{\DD}: \exists X\in\Ob{\CC} : F(X) \cong Y.
 \]
 \end{rem}
-So motivated by the remark, we define:
+So, motivated by the remark, we define:
 \begin{dfn} Categories $\CC$ and $\DD$ are \textbf{equivalent} if there exists a pair of functors $(F:\CC\to\DD, G:\DD\to\CC)$ such that there exists natural isomorphisms 
 \[
 \co{F}{G} \to \Id[\CC], \quad \co{G}{F} \to \Id[\DD]
 \]
 \end{dfn}
 
-So although $U$ is not an isomorphism, it does induce an equivalence of categories:
+So, although $U$ is not an isomorphism, it does induce an equivalence of categories:
 \begin{exer} Show that $U$ induces an equivalence of categories.
 \end{exer}
 
@@ -1724,7 +1724,7 @@ The following exercise gives a characterization of a functor being an equivalenc
 \exists x: P(x),
 \]
 then we can fix some $x$ such that $P(x)$ holds.
-\begin{exer} Show that a functor $F:\CC\to\DD$ induces an equivalences of categories if and only if it is essentially surjective on objects and fully faithful.
+\begin{exer} Show that a functor $F:\CC\to\DD$ induces an equivalence of categories if and only if it is essentially surjective on objects and fully faithful.
 \end{exer}
 
 
@@ -1744,7 +1744,7 @@ The choice of topics was guided by the applications to programming we considered
 \item Altenkirch and Reus show how the lambda calculus forms a monad.
   (This can be generalized to other languages, including languages with simple types, see, e.g., \cite{DBLP:journals/jfrea/AhrensZ11}.)
 \item For \emph{nested} datatypes, the iteration principle of \cref{sec:datatypes-as-initial} is often not enough; Bird and Paterson~\cite{DBLP:journals/fac/BirdP99} develop a \emph{generalized} fold operator for nested datatypes.
-\item Some functions cannot straightforwardly defined using the simple iteration scheme of \cref{sec:datatypes-as-initial}; for instance, the factorial function does not adhere to the required pattern.
+\item Some functions cannot be straightforwardly defined using the simple iteration scheme of \cref{sec:datatypes-as-initial}; for instance, the factorial function does not adhere to the required pattern.
   Vene~\cite{vene_phd} studies more general recursion schemes beyond the iteration (catamorphisms) of~\cref{sec:datatypes-as-initial}.
 \item Harper~\cite{DBLP:phd/ethos/Harper13} develops a unifying framework for shortcut fusion.
 

--- a/tex/adjunctions.tex
+++ b/tex/adjunctions.tex
@@ -29,11 +29,11 @@ If $(F,G)$ is an adjoint pair, we call $F$ the \textbf{left adjoint} of $G$ and 
 \[
 - \times Y : \SET\to \SET: X\mapsto X\times Y,
 \]
-has a right adjoint which is given by the functor (induced by the following mapping on objects)
+has a right adjoint, which is given by the functor (induced by the following mapping on objects)
 \[
 \CHom{\SET}{Y}{-} : \SET\to\SET : X\mapsto \CHom{\SET}{Y}{X}.
 \]
-Is there an analoguous statement in the category $\LEAN$ instead of $\SET$?
+Is there an analogous statement in the category $\LEAN$ instead of $\SET$?
 \end{exer}
 
 \begin{thm} Let $(F,G)$ be a pair of functors $F : \CC\to\DD, G: \DD\to\CC$. The following statements are equivalent:
@@ -57,7 +57,7 @@ G(D) \arrow[r,"{\eta_{G(D)}}"] \arrow[rd,swap, "{\Id[G(D)]}"] & G(F(G(D))) \arro
 \end{enumerate}
 In case $(F,G)$ satisfies these (equivalent) conditions, we call $\eta$ the \textbf{unit of the adjunction} and $\epsilon$ the \textbf{counit of the adjunction}. The equalities in condition $2$ are called the \textbf{triangle identities}.
 \begin{proof}
-First assume that $(F,G)$ is an adjoint pair. We have to define the unit and counit and show that the triangle identities hold:
+First, assume that $(F,G)$ is an adjoint pair. We have to define the unit and counit and show that the triangle identities hold:
 \begin{itemize}
 \item \textbf{Unit}: For each $X\in\Ob{\CC}$, we should first define $\eta_X \in \CHom{\CC}{X}{G(F(X))}$. Since $F \dashv G$, we have a bijection
 \[
@@ -79,8 +79,8 @@ where the first and last equality hold by naturality of $\alpha$.
 \[
 \alpha^{-1}_{GY,Y} : \CHom{\CC}{GY}{GY}\to \CHom{\DD}{F(G(Y))}{Y}.
 \]
-That $\epsilon$ indeed forms a natural transformation is analoguous to the computation in \cref{eqn:unitnaturality_fromhomsetadj}.
-\item \textbf{Triangle identities}: Both the triangle identities are proved analoguously, hence we will only show the first triangle identity, i.e. $\Id[FX] = \co{F(\eta_X)}{\epsilon_{FX}}$. Unfolding the definition of $\epsilon$, this is equivalent to showing:
+That $\epsilon$ indeed forms a natural transformation is analogous to the computation in \cref{eqn:unitnaturality_fromhomsetadj}.
+\item \textbf{Triangle identities}: Both the triangle identities are proved analogously, hence we will only show the first triangle identity, i.e. $\Id[FX] = \co{F(\eta_X)}{\epsilon_{FX}}$. Unfolding the definition of $\epsilon$, this is equivalent to showing:
 \[
 \Id[FX] = \co{F(\eta_X)}{\alpha^{-1}_{GFX,FX}(\Id[GF(X)])}.
 \]
@@ -106,7 +106,7 @@ For the other direction, let $f\in \CHom{\CC}{X}{G(Y)}$. Define $\alpha^{-1}_{X,
 \[
 FX \xrightarrow{F(f)} F(G(Y)) \xrightarrow{\epsilon_Y} Y.
 \]
-That $\alpha$ and $\alpha^{-1}$ are inverses of eachother follows from the following computation:
+That $\alpha$ and $\alpha^{-1}$ are inverses of each other follows from the following computation:
 \begin{eqnarray*}
 \alpha(\alpha^{-1}(f)) = \alpha(\co{F(f)}{\epsilon_Y}) =& \co{\eta_X}{G(\co{F(f)}{\epsilon_Y})} &\text{ by definition, }\\
 	=& \co{\eta_X}{(\co{GF(f)}{G\epsilon_Y})} &\text{ by functoriality of $G$},\\
@@ -115,7 +115,7 @@ That $\alpha$ and $\alpha^{-1}$ are inverses of eachother follows from the follo
 	=& \co{f}{(\co{\eta_{GY}}{G\epsilon_Y})} &\text{ by associativity}\\
 	=& f &\text{by triangle identity}.
 \end{eqnarray*}
-The other equality is shown analoguous by using functoriality of $F$, naturality of $\epsilon$ and the other triangle identity.
+The other equality is shown analogous by using functoriality of $F$, naturality of $\epsilon$ and the other triangle identity.
 
 It remains to show the naturality of $\alpha$ in both $x$ and $y$ which is left to the reader as a good exercise on diagram chasing. %\KW{TODO: Give the proof of the naturality}
 \end{proof}

--- a/tex/contravariant.tex
+++ b/tex/contravariant.tex
@@ -1,8 +1,8 @@
 \subsection{Contravariant functors}
 
 A variation on functors are \textbf{contravariant functors}.
-A contravariant functor consists of a map on objects just like a functor.
-However, the \textbf{map on morpisms turns the morphisms around}.
+A contravariant functor consists of a map on objects, just like a functor.
+However, the \textbf{map on morphisms turns the morphisms around}.
 We give the formal definition:
 
 \begin{dfn} Let $\CC$ and $\DD$ be categories. A \textbf{contravariant functor} $F$ from $\CC$ to $\DD$ consists of the following data:
@@ -25,7 +25,7 @@ Moreover, this data should satisfy the following properties:
 \end{itemize}
 \end{dfn}
 
-\begin{exer} Notice that the preservation of composition has now changed, why is this the case?
+\begin{exer} Notice that the preservation of composition has now changed; why is this the case?
 \end{exer}
 
 An example of a contravariant functor is given by the powerset-functor:

--- a/tex/forget-free.tex
+++ b/tex/forget-free.tex
@@ -14,7 +14,7 @@ Recall that a monoid is a set $M$ together with a binary operation $m:M\to M\to 
 \]
 \end{itemize}
 \end{exa}
-Notice that if one defines a category whose objects are sets $M$ together with an associative binary operation $m:M\to M\to M$, then one could analoguously also define a forgetful functor from $\MON$ to this category by only forgetting the neutral element.
+Notice that if one defines a category whose objects are sets $M$ together with an associative binary operation $m:M\to M\to M$, then one could analogously also define a forgetful functor from $\MON$ to this category by only forgetting the neutral element.
 
 \begin{lemma} The forgetful functor from $\MON$ to $\SET$ satisfies the properties of a functor.
 \begin{proof}
@@ -82,7 +82,7 @@ Show that for any set $X$ and monoid $(M,m,e)$, there exist bijections between t
 Hint: use \cref{prop:UVP_forget_montoset}.
 \end{exer}
 
-\begin{exer} Define a forgetful functor from the category $\POS$ of posets (defined in \cref{example:poset}) to $\SET$ analoguous to the the forgetful functor from $\MON$ to $\SET$ (defined in \cref{example:forgetful_montoset}).
+\begin{exer} Define a forgetful functor from the category $\POS$ of posets (defined in \cref{example:poset}) to $\SET$ analogous to the the forgetful functor from $\MON$ to $\SET$ (defined in \cref{example:forgetful_montoset}).
 \end{exer}
 \begin{rem} The story about free monoids can not be repeated for posets, i.e. there is no free poset structure on all sets. But in order to prove this one needs more machinery.
 \end{rem}

--- a/tex/monads.tex
+++ b/tex/monads.tex
@@ -107,10 +107,10 @@ The notion of a Kleisli triple can equivalently be described  as follows:
 A \textbf{monad} over a category $\CC$ consists of the following data:
 \begin{itemize}
 \item A (endo)functor $T:\CC\to\CC$.
-\item A natural transformation $\NatTrans{\eta}{\Id[\CC]}{T}$.
+\item A natural transformation (``unit'') $\NatTrans{\eta}{\Id[\CC]}{T}$.
 \item A natural transformation (``multiplication'') $\NatTrans{\mu}{\co{T}{T}}{T}$.
 \end{itemize}
-such that for each $X\in\Ob{\CC}$ the following diagrams commute:
+such that for each $X\in\Ob{\CC}$ the following diagrams commute (``associativity'' and ``unit'' laws):
 \begin{center}
 \begin{tikzcd}
 T^3(X) \arrow[r, "\mu_{T(X)}"] \arrow[d,swap, "T(\mu_X)"] & T^2(X) \arrow[d, "\mu_X"] \\

--- a/tex/solutions.tex
+++ b/tex/solutions.tex
@@ -102,7 +102,7 @@ That this data satisfies the properties of a category, follows because $\CC$ is 
 \co{\op{\Id}}{\op{f}} = \op{(\co{f}{\Id})} = \op{f},
 \]
 where the first equality holds by definition of the \textit{opposite composition} and the second holds by the right unit law of $\CC$.\\
-The right unit law holds analoguously by the left unit law of $\CC$.
+The right unit law holds analogously by the left unit law of $\CC$.
 \item That the associativity holds follows by the associativity of $\CC$ as follows:
 \begin{eqnarray*}
 \co{\op{h}}{(\co{\op g}{\op f})} &=& \co{\op{h}}{\op{(\co{f}{g})}}\\
@@ -156,7 +156,7 @@ We define $h := \co{g^{-1}}{f^{-1}}$. The left equality then holds by the follow
 	=& \co{f^{-1}}{f} &\text{ by unit law,}\\
 	=& \Id[a] &\text{ since $f^{-1}$ inverse of $f$.}
 \end{eqnarray*}
-The right equality holds analoguously.
+The right equality holds analogously.
 \end{solution}
 
 
@@ -265,7 +265,7 @@ Since $f$ is injective, it suffices to show
 \forall z\in Z: f(g(z))=f(h(z)).
 \]
 But this holds by the condition of $g$ and $h$. Hence, $f$ is indeed a monomorphism.
-\item Assume $f$ is a monomorphism. We have to show that for each $x_1,x_2\in X$, we have $f(x_1) = f(x_2)$. Let $\mathbf{1} = \{\star\}$ be a singleton set and define
+\item Assume $f$ is a monomorphism. We have to show that for all $x_1,x_2\in X$, $f(x_1) = f(x_2)$ implies $x_1 = x_2$. Let $\mathbf{1} = \{\star\}$ be a singleton set and define
 \[
 g_1 : \mathbf{1}\to X: \star\mapsto x_1,\quad  g_2 : \mathbf{1}\to X: \star\mapsto x_2, 
 \]
@@ -274,13 +274,13 @@ Since $f(x_1)=f(x_2)$, we have $\co{g_1}{f} = \co{g_2}{f}$. But $f$ is a monomor
 \end{solution}
 
 \begin{solution}[\cref{exer:sections_in_set_injective}]\label{sol:sections_in_set_injective}
-Let $f:X\to Y$ be a section with a retraction $h:Y\to X$, i.e. $\co{f}{h} = \Id[Y]$. By \cref{ex:mono-inj}, it suffices to show that $f$ is a monomorphism. Let  $g_1, g_2 : Z \to X$ be morphisms in $\SET$ such that $\co{g_1}{f} = \co{g_2}{f}$. We have to show $g_1=g_2,$, this follows from the following computation:
+Let $f:X\to Y$ be a section with a retraction $h:Y\to X$, i.e. $\co{f}{h} = \Id[Y]$. By \cref{ex:mono-inj}, it suffices to show that $f$ is a monomorphism. Let  $g_1, g_2 : Z \to X$ be morphisms in $\SET$ such that $\co{g_1}{f} = \co{g_2}{f}$. We have to show $g_1=g_2$, which follows from the following computation:
 \begin{eqnarray*}
 g_1 =& \co{g_1}{\Id[Y]} & \text{ by unit law},\\ 
-	=& \co{g_1}{\co{f}{h}} & \text{ since $f$ section},\\ 
-	=& \co{\co{g_1}{f}}{h} & \text{ by associativity},\\
-	=&  \co{\co{g_2}{f}}{h} & \text{ by assumption},\\
-	=& \co{g_2}{\co{f}{h}} & \text{ by associativity},\\ 
+	=& \co{g_1}{(\co{f}{h})} & \text{ since $f$ section},\\ 
+	=& \co{(\co{g_1}{f})}{h} & \text{ by associativity},\\
+	=&  \co{(\co{g_2}{f})}{h} & \text{ by assumption},\\
+	=& \co{g_2}{(\co{f}{h})} & \text{ by associativity},\\ 
 	=& \co{g_2}{\Id[Y]} & \text{ since $f$ section},\\
 	=& g_2 & \text{ by unit law}.
 \end{eqnarray*}
@@ -290,7 +290,7 @@ Notice that this proof shows that in an arbitrary category, a section is always 
 \begin{solution}[\cref{exer:iso_to_monoepi}]\label{sol:iso_to_monoepi}
 Let $f : a\cong b$ be an isomorphism with inverse $f^{-1}$. There are multiple proofs which one can give, an abstract one (which is \textit{indirect} in the sense that we use another exercise/lemma) and a more \textit{direct} one.
 \begin{itemize}
-\item \textbf{Indirect proof:} By the solution of \ref{exer:sections_in_set_injective}, we know that any section (from a section-retraction pair) is a monomorphism. An analoguous argument shows that any retraction (section-retraction pair) is an epimorphism. Hence it suffices to show that $f$ is both a section and a retraction, but this is immediate because $\co{f}{f^{-1}} = \Id[a]$ and $\co{f^{-1}}{f} = \Id[b]$.
+\item \textbf{Indirect proof:} By the solution of \ref{exer:sections_in_set_injective}, we know that any section (from a section-retraction pair) is a monomorphism. An analogous argument shows that any retraction (section-retraction pair) is an epimorphism. Hence it suffices to show that $f$ is both a section and a retraction, but this is immediate because $\co{f}{f^{-1}} = \Id[a]$ and $\co{f^{-1}}{f} = \Id[b]$.
 \item \textbf{Direct proof:} We first show that $f$ is a monomorphism. Assume $g_1,g_2 : c\to a$ are morphisms such that $\co{g_1}{f} = \co{g_2}{f}$. We then have that $g_1 = g_2$ because 
 \begin{eqnarray*}
 g_1 = \co{g_1}{\Id[a]} =& \co{g_1}{(\co{f}{f^{-1}})} & \text{ since $f : a\cong b$},\\ 
@@ -300,7 +300,7 @@ g_1 = \co{g_1}{\Id[a]} =& \co{g_1}{(\co{f}{f^{-1}})} & \text{ since $f : a\cong 
 	=& \co{g_2}{\Id[a]} & \text{ since $f : a\cong b$} \\
 	=& g_2.
 \end{eqnarray*}
-That $f$ is also an epimorphism is analoguous, indeed: Assume $g_1,g_2 : b\to c$ are morphisms such that $\co{f}{g_1} = \co{f}{g_2}$. We then have that $g_1 = g_2$ because 
+That $f$ is also an epimorphism is analogous, indeed: Assume $g_1,g_2 : b\to c$ are morphisms such that $\co{f}{g_1} = \co{f}{g_2}$. We then have that $g_1 = g_2$ because 
 \begin{eqnarray*}
 g_1 = \co{\Id[b]}{g_1} =& \co{(\co{f^{-1}}{f})}{g_1} & \text{ since $f : a\cong b$},\\ 
 	=& \co{f^{-1}}{(\co{f}{g_1})} & \text{ by associativity}, \\ 
@@ -459,7 +459,7 @@ We do a pattern matching on $f(x)$ to show \cref{eqn:bind_distributes}:
 \[
 g^{*}(\nil + f^{*}(xs)) = g^{*}(f^{*}(xs)) = \nil + g^{*}(f^{*}(xs)) = g^{*}(\nil) + g^{*}(f^{*}(xs)),
 \]
-where the thirth equality holds by \cref{eq:list-bind-nil}.
+where the third equality holds by \cref{eq:list-bind-nil}.
 \item In case $f(x) = \cons(y,u)$, with $y\in Y$ and $u\in \List Y$, we have:
 \begin{eqnarray*}
 g^{*}(\cons(f(x),f^{*}(s)) =& g^{*}(\cons(\cons(y,u), f^{*}(xs))), \\
@@ -468,7 +468,7 @@ g^{*}(\cons(f(x),f^{*}(s)) =& g^{*}(\cons(\cons(y,u), f^{*}(xs))), \\
 	=& g(y) + g^{*}(u) + g^{*}(f^{*}(xs)),\\
 	=& g^{*}(\cons(y,u)) + g^{*}(f^{*}(xs)).
 \end{eqnarray*}
-where the second equality holds by definition of $\cons$, the thirth and fifth by definition of $g^{*}$ and the fourth by the induction hypothesis.
+where the second equality holds by definition of $\cons$, the third and fifth by definition of $g^{*}$ and the fourth by the induction hypothesis.
 
 \end{itemize}
 \end{itemize}
@@ -537,7 +537,7 @@ Hence, by the induction hypothesis, the both sides are equal.
 \label{sol:kleisli_triple_maybe}
 Before we continue with this exercise, we first fix some notation. Since $X+E$ is the disjoint union of $X$ and $E$, we have the canonical inclusions which we denote by
 \[ i^X_l : X\to X + E, \quad i^X_r : E\to X+E. \] 
-Hence, a function whose domain is $X+E$ is completely determined by specifiying where each $i^X_l(x)$ and each $i^X_r(e)$ are mapped to. \textit{Notice that this is precisely the notation and the universal property of the coproduct (in $\SET$)}.
+Hence, a function whose domain is $X+E$ is completely determined by specifying where each $i^X_l(x)$ and each $i^X_r(e)$ are mapped to. \textit{Notice that this is precisely the notation and the universal property of the coproduct (in $\SET$)}.
 
 For each set $X\in\Ob \SET$, we define:
 \[
@@ -668,7 +668,7 @@ The right-hand-side is given as:
 \[
 (\co{f}{g^{*}})^{*}(i) = \lambda j, i\left((\co{f}{g^{*}})(-)(j)\right)
 \]
-So to show that both sides are equal, it sufficies to show that for each $j$, we have 
+So to show that both sides are equal, it suffices to show that for each $j$, we have 
 \[
 f(-)\left(g(-)(j)\right) = (\co{f}{g^{*}})(-)(j).
 \]


### PR DESCRIPTION
Fixed some typos and punctuation.
Added "associativity and unit laws" in the monads section. 