### PR TITLE
Monads

### DIFF
--- a/tex/monads.tex
+++ b/tex/monads.tex
@@ -79,16 +79,19 @@ where $\BinTree(X)$ is the set of binary trees labelled with elements from $X$ a
 The resulting monad is called the \textbf{Tree monad}.
 \end{exer}
 
-
-
-\begin{exer}[\cref{sol:kleisli_triple_maybe}]\label{exer:kleisli_triple_maybe} Let $E$ be a set (considered as a set of \textit{exceptions}). Show how the following assignment induces a Kleisli triple over the category $\SET$:
+\begin{exer}[\cref{sol:kleisli_triple_exception}]\label{exer:kleisli_triple_exception} Let $E$ be a set (considered as a set of \textit{exceptions}). Show how the following assignment induces a Kleisli triple over the category $\SET$:
 \[
 X\mapsto (X + E),
 \]
 The resulting monad is called the \textbf{Exception monad}.
 \end{exer}
 
-
+\begin{exer}[\cref{sol:kleisli_triple_side_effects}]\label{exer:kleisli_triple_side_effects} Let $S$ be a set (considered as a set of states, e.g. a set of stores or a set of input/output sequences). Show how the following assignment induces a Kleisli triple over the category $\SET$:
+\[
+X\mapsto S \to (X \times S),
+\]
+The resulting monad is called the \textbf{Monad of side-effects}.
+\end{exer}
 
 \begin{exer}[\cref{sol:kleisli_triple_nondeterminism}]\label{exer:kleisli_triple_nondeterminism} Show how the following assignment induces a Kleisli triple over the category $\SET$:
 \[

--- a/tex/monads.tex
+++ b/tex/monads.tex
@@ -168,7 +168,7 @@ Every Kleisli triple induces a category:
 \item $\Ob{(\CC_T)} := \Ob{\CC}$.
 \item For each $X,Y\in\Ob{(\CC_T)}$, $\CHom{\CC_T}{X}{Y} := \CHom{\CC}{X}{TY}$.
 \item The identity on $X\in\Ob{(\CC_T)}$ is $\eta_X$.
-\item The composition of $f\in \CHom{\CC_T}{X}{Y}$ and $f\in \CHom{\CC_T}{Y}{Z}$ is $\co{f}{g^{*}}$.
+\item The composition of $f\in \CHom{\CC_T}{X}{Y}$ and $g\in \CHom{\CC_T}{Y}{Z}$ is $\co{f}{g^{*}}$.
 \end{itemize}
 \end{dfn}
 

--- a/tex/solutions.tex
+++ b/tex/solutions.tex
@@ -1352,7 +1352,7 @@ We wish to define $h : \Stream(A)\times\Stream(B)\to A\times B$ and $t: \Stream(
 	\Stream(A\times B) 
 		\arrow[rr, swap, "{\langle \head, \tail \rangle}"] 
 	&& 
-	{\Stream(A\times B)}
+	{A \times B \times \Stream(A\times B)}
 	\end{tikzcd}
 	\end{center}
 	

--- a/tex/solutions.tex
+++ b/tex/solutions.tex
@@ -863,7 +863,7 @@ Hence, both sides are equal.
 \label{sol:kleisli_triple_continuation}
 For each set $X\in\Ob \SET$, we define:
 \[
-\eta_X : X \to (X\to R)\to R : x\mapsto (\lambda f. f(x)).
+\eta_X : X \to (X\to R)\to R : x\mapsto (\lambda f, f(x)).
 \]
 For each function $f\in\CHom{\Ob \SET}{X}{Cont^R(Y)}$, we define:
 \begin{align*}

--- a/tex/solutions.tex
+++ b/tex/solutions.tex
@@ -794,7 +794,7 @@ g^{*}(f^{*}(z)) = g^{*}(f^{*}(i_l^X(e))) = g^{*}(i_l^Y(e)) = i_l^Z(e) = (\co{f}{
 	We now show that the properties of a Kleisli triple hold:
 	\begin{enumerate}
 	\item For each set $X$, we have to show $\eta_X^{*} = \Id[S \to X \times S]$. For each $c : S \to X \times S$ and $s : S$ we have:
-	$$\eta^*_X (c) (s)= (\eta_X) (\pi_l (c(s))) (\pi_r (c(s))) = (\pi_l (c(s)), \pi_r (c(s))) = c (s).$$
+	\[\eta^*_X (c) (s)= (\eta_X) (\pi_l (c(s))) (\pi_r (c(s))) = (\pi_l (c(s)), \pi_r (c(s))) = c (s).\]
 	
 	\item For each function $f:X\to S \to Y \times S$, we have to show $f^{*}(\eta_X(x)) = f(x)$ for all $x \in X$. For each $s : S$ we have: 
 	$$ f^* (\eta_X (x)) (s) = f^* (\lambda s: S, (x,s)) (s) = f (\pi_l (x,s)) (\pi_r (x,s)) = f (x)(s) $$

--- a/tex/solutions.tex
+++ b/tex/solutions.tex
@@ -719,8 +719,8 @@ Hence, by the induction hypothesis, the both sides are equal.
 \end{enumerate}
 \end{solution}
 
-\begin{solution}[\cref{exer:kleisli_triple_maybe}]
-\label{sol:kleisli_triple_maybe}
+\begin{solution}[\cref{exer:kleisli_triple_exception}]
+\label{sol:kleisli_triple_exception}
 Before we continue with this exercise, we first fix some notation. Since $X+E$ is the disjoint union of $X$ and $E$, we have the canonical inclusions which we denote by
 \[ i^X_l : X\to X + E, \quad i^X_r : E\to X+E. \] 
 Hence, a function whose domain is $X+E$ is completely determined by specifying where each $i^X_l(x)$ and each $i^X_r(e)$ are mapped to. \textit{Notice that this is precisely the notation and the universal property of the coproduct (in $\SET$)}.
@@ -773,6 +773,43 @@ g^{*}(f^{*}(z)) = g^{*}(f^{*}(i_l^X(e))) = g^{*}(i_l^Y(e)) = i_l^Z(e) = (\co{f}{
 
 \end{enumerate}
 \end{solution}
+
+\begin{solution}[\cref{exer:kleisli_triple_side_effects}]
+	\label{sol:kleisli_triple_side_effects}
+	For each set $X\in\Ob \SET$, we define:
+	\[
+	\eta_X : X \to S \to X \times S : x\mapsto (\lambda s: S, (x,s)).
+	\]
+	For each function $f\in\CHom{\Ob \SET}{X}{S \to Y \times S}$, and each $c : S \to X \times S$, we define:
+	\begin{align*}
+	f^{*} (c) : S & \to Y \times S  \\
+	s & \mapsto (f (\pi_l(c(s))) (\pi_r (c(s)))),
+	\end{align*}
+	where $\pi_l$ and $\pi_r$ are the left and right projections of the product. 
+	
+	We now show that the properties of a Kleisli triple hold:
+	\begin{enumerate}
+	\item For each set $X$, we have to show $\eta_X^{*} = \Id[S \to X \times S]$. For each $c : S \to X \times S$ and $s : S$ we have:
+	$$\eta^*_X (c) (s)= (\eta_X) (\pi_l (c(s))) (\pi_r (c(s))) = (\pi_l (c(s)), \pi_r (c(s))) = c (s).$$
+	
+	\item For each function $f:X\to S \to Y \times S$, we have to show $f^{*}(\eta_X(x)) = f(x)$ for all $x \in X$. For each $s : S$ we have: 
+	$$ f^* (\eta_X (x)) (s) = f^* (\lambda s: S, (x,s)) (s) = f (\pi_l (x,s)) (\pi_r (x,s)) = f (x)(s) $$
+	
+	\item Let $f:X\to S \to Y \times S$ and $g:Y\to S \to Z \times S$ be functions, we have to show for each $c : S \to X \times S$:
+	\[
+	g^{*}(f^{*}(c)) = (\co{f}{g^{*}})^{*}(c).
+	\] 
+	From the left hand side we have: 
+	\begin{align*}
+	g^* (f^* (c)) & = g^* (\lambda s : S, f (\pi_l (c(s))) (\pi_r (c(s)))) = (\lambda s : S, g^* (f (\pi_l (c(s))) (\pi_r (c(s))))) \\
+	& = (\lambda s : S, (g^* \circ f) (\pi_l (c(s))) (\pi_r (c(s)))),
+	\end{align*}
+	and from the right hand side we have:
+	$$ (g^* \circ f)^* (c) = (\lambda s : S, (g^* \circ f) (\pi_l (c(s))) (\pi_r (c(s)))).$$ 
+	Hence, the left and right hand sides are equal. 
+	\end{enumerate}
+	\end{solution}
+	
 
 \begin{solution}[\cref{exer:kleisli_triple_nondeterminism}]
   \label{sol:kleisli_triple_nondeterminism}

--- a/tex/solutions.tex
+++ b/tex/solutions.tex
@@ -611,7 +611,7 @@ We now show that the properties of a Kleisli triple hold:
   
   
 
-\item For each function $f:X\to Y$, we have to show $f^{*}(\eta_X(x)) = f(x)$, this indeed holds by the following computation:
+\item For each function $f:X\to \List Y$, we have to show $f^{*}(\eta_X(x)) = f(x)$, this indeed holds by the following computation:
 \[
 f^{*}(\eta_X(x)) = f^{*}(\cons(x,\nil)) = \cons(fx, f^{*}(\nil)) = \cons(fx, \nil),
 \]
@@ -690,7 +690,7 @@ We now show that the properties of a Kleisli triple hold:
 \]
 \end{itemize}
 
-\item For each function $f:X\to Y$, we have to show $f^{*}(\eta_X(a)) = f(a)$, this indeed holds by the following computation:
+\item For each function $f:X\to \BinTree Y$, we have to show $f^{*}(\eta_X(a)) = f(a)$, this indeed holds by the following computation:
 \[
 f^{*}(\eta_X(a)) = f^{*}(\Leaf{a}) = f(a).
 \]
@@ -702,13 +702,17 @@ g^{*}(f^{*}(t)) = (\co{f}{g^{*}})^{*}(t).
 That this equality holds follows by pattern matching:
 \begin{itemize}
 \item If $t= \Leaf{a}$, then
-\[
-g^{*}(f^{*}(t)) = g^{*}(f^{*}(\Leaf{a}) = g^{*}(f(a)) = (\co{f}{g^{*}})(a) = (\co{f}{g^{*}})^{*}(\Leaf{a}) = (\co{f}{g^{*}})^{*}(t).
-\]
+\begin{align*}
+	g^{*}(f^{*}(t)) & = g^{*}(f^{*}(\Leaf{a})) = g^{*}(f(a)) = (\co{f}{g^{*}})(a) = (\co{f}{g^{*}})^{*}(\Leaf{a}) \\
+	& = (\co{f}{g^{*}})^{*}(t).	
+\end{align*}
+
 \item If $t=\Branch{t_1}{t_2}$, then is the left-hand-side given by
-\[
-g^{*}(f^{*}(t)) = g^{*}(f^{*}(\Branch{t_1}{t_2})) = g^{*}\left(\Branch{f^{*}(t_1)}{f^{*}(t_2)}\right) = \Branch{g^{*}(f^{*}(t_1))}{g^{*}(f^{*}(t_2))}.
-\]
+\begin{align*}
+	g^{*}(f^{*}(t)) & = g^{*}(f^{*}(\Branch{t_1}{t_2})) = g^{*}\left(\Branch{f^{*}(t_1)}{f^{*}(t_2)}\right) \\
+	& = \Branch{g^{*}(f^{*}(t_1))}{g^{*}(f^{*}(t_2))}.	
+\end{align*}
+
 The right-hand-side is given by 
 \[
 (\co{f}{g^{*}})^{*}(t) = (\co{f}{g^{*}})^{*}(\Branch{t_1}{t_2}) = \Branch{(\co{f}{g^{*}})(t_1)}{(\co{f}{g^{*}})(t_2)}.
@@ -753,7 +757,7 @@ We now show that the properties of a Kleisli triple hold:
 \]
 \end{itemize}
 
-\item For each function $f:X\to Y$, we have to show $f^{*}(\eta_X(x)) = f(x)$ but this holds directly by the definition of $(-)^{*}$ since $\eta_X(x)=i_l^X(x)$.
+\item For each function $f:X\to Y + E$, we have to show $f^{*}(\eta_X(x)) = f(x)$ but this holds directly by the definition of $(-)^{*}$ since $\eta_X(x)=i_l^X(x)$.
 
 \item Let $f:X\to Y + E$ and $g:Y\to Z + E$ be functions, we have to show 
 \[
@@ -833,7 +837,7 @@ We now show that the properties of a Kleisli triple hold:
 \eta_X^{*}(A) = \bigcup_{a\in A} \eta_X(a) = \bigcup_{a\in A} \{a\} = A = \Id[\mathbb{P}_{fin}(X)](A).
 \]
 
-\item For each function $f:X\to Y$, we have to show $f^{*}(\eta_X(x)) = f(x)$ but this holds directly by the definition of $(-)^{*}$ since
+\item For each function $f:X\to \mathbb{P}_{fin}(Y)$, we have to show $f^{*}(\eta_X(x)) = f(x)$ but this holds directly by the definition of $(-)^{*}$ since
 \[
 f^{*}(\eta_X(x)) = f^{*}(\{x\}) = \bigcup_{a\in \{x\}} f(a) = f(x).
 \]
@@ -848,7 +852,7 @@ g^{*}(f^{*}(A)) = g^{*}\left( \bigcup_{a\in A} f(a) \right) = \bigcup_{b \in \bi
 \]
 The right-hand-side is given as:
 \[
-(\co{f}{g^{*}})^{*}(A) = \bigcup_{a\in A} (\co{f}{g^{*}})(a) = \bigcup_{a\in A} g^{*}(f(a)) = \bigcup_{a\in A} \bigcup_{b\in f(a)} g(f(a))
+(\co{f}{g^{*}})^{*}(A) = \bigcup_{a\in A} (\co{f}{g^{*}})(a) = \bigcup_{a\in A} g^{*}(f(a)) = \bigcup_{a\in A} \bigcup_{b\in f(a)} g(f(a)).
 \]
 Hence, both sides are equal.
 
@@ -871,10 +875,10 @@ Let $i\in Cont^R(X)$. We now show that this data satisfies the properties of a K
 \begin{enumerate}
 \item For each set $X$, we have to show $\eta_X^{*} = \Id[Cont^R(X)]$. Let $x\in X$. The claim then follows by the following computation:
 \[
-\eta_X^{*}(i) = \lambda j, i\left(\eta_X(-)(j)\right) = \lambda j, i\left(\lambda x, j(x)\right) = i
+\eta_X^{*}(i) = \lambda j, i\left(\eta_X(-)(j)\right) = \lambda j, i\left(\lambda x, j(x)\right) = i.
 \]
 
-\item For each function $f:X\to Y$, we have to show $f^{*}(\eta_X(x)) = f(x)$, this follows by the following computation:
+\item For each function $f:X\to Cont^R(Y)$, we have to show $f^{*}(\eta_X(x)) = f(x)$, this follows by the following computation:
 \[
 f^{*}(\eta_X(x)) = f^{*}(\lambda g,g(x)) = \lambda j, \left(\left(\lambda g,g(x)\right)(f(-)(j))\right) = \lambda j, (f(x)(j)) = f(x).
 \]
@@ -884,12 +888,14 @@ f^{*}(\eta_X(x)) = f^{*}(\lambda g,g(x)) = \lambda j, \left(\left(\lambda g,g(x)
 g^{*}(f^{*}(i)) = (\co{f}{g^{*}})^{*}(i).
 \] 
 The left-hand-side is given as:
-\[
-g^{*}(f^{*}(i)) = g^{*}\left(\lambda j, i\left(f(-)(j)\right)\right) = \lambda \tilde{j}, \left(\lambda j, i\left(f(-)(j)\right)\right)\left(g(-)(\tilde{j})\right) = \lambda \tilde{j}, i\left(f(-)\left(g(-)(\tilde{j})\right)\right).
-\]
+\begin{align*}
+	g^{*}(f^{*}(i)) & = g^{*}\left(\lambda j, i\left(f(-)(j)\right)\right) = \lambda \tilde{j}, \left(\lambda j, i\left(f(-)(j)\right)\right)\left(g(-)(\tilde{j})\right) \\
+	& = \lambda \tilde{j}, i\left(f(-)\left(g(-)(\tilde{j})\right)\right).
+\end{align*}
+
 The right-hand-side is given as:
 \[
-(\co{f}{g^{*}})^{*}(i) = \lambda j, i\left((\co{f}{g^{*}})(-)(j)\right)
+(\co{f}{g^{*}})^{*}(i) = \lambda j, i\left((\co{f}{g^{*}})(-)(j)\right).
 \]
 So to show that both sides are equal, it suffices to show that for each $j$, we have 
 \[
@@ -897,7 +903,7 @@ f(-)\left(g(-)(j)\right) = (\co{f}{g^{*}})(-)(j).
 \]
 Notice that these are functions $X\to R$. Hence we will show this pointwise for each $x\in X$. The left-hand-side is given by: 
 \[
-f(-)\left(g(-)(j)\right)(x) = f(x)\left(g(-)(j)\right) 
+f(-)\left(g(-)(j)\right)(x) = f(x)\left(g(-)(j)\right).
 \]
 The right-hand-side is given by:
 \begin{eqnarray*}
@@ -929,10 +935,12 @@ We now show that this data satisfies the properties of a Kleisli triple:
 \[
 \eta_X^{*}(g)(r) = \eta_X(g(r))(r) = (\lambda \_, g(r))(r) = g(r).
 \]
-\item For each $x\in X$ and $r\in R$, we have to show $\co{\eta_X}{f^{*}} = f$. The claim then follows by the following computation (using functional extensionality):
-\[
-f^{*}(\eta_X(x))(r) = f^{*}(\lambda \_,x)(r) = \left(\lambda r', f((\lambda \_, x)(r'))(r')\right)(r) = f((\lambda \_,x)(r))(r) = f(x)(r).
-\]
+\item Let $f: X\to (R\to Y)$. We have to show that $\co{\eta_X}{f^{*}} = f$, which follows from the following computation using functional extensionality. For each $x\in X$ and $r\in R$:
+\begin{align*}
+	f^{*}(\eta_X(x))(r) & = f^{*}(\lambda \_,x)(r) = \left(\lambda r', f((\lambda \_, x)(r'))(r')\right)(r) = f((\lambda \_,x)(r))(r) \\
+	& = f(x)(r).
+\end{align*}
+
 \item Let $f: X\to (R\to Y)$ and $g: Y\to (R\to Z)$. We have to show, by function extensionality, that for any $\phi\in R\to X$, we have 
 \[
 (\co{f}{g^{*}})^{*}(\phi) = g^{*}(f^{*}(\phi)).

--- a/tex/solutions.tex
+++ b/tex/solutions.tex
@@ -797,7 +797,7 @@ g^{*}(f^{*}(z)) = g^{*}(f^{*}(i_l^X(e))) = g^{*}(i_l^Y(e)) = i_l^Z(e) = (\co{f}{
 	\[\eta^*_X (c) (s)= (\eta_X) (\pi_l (c(s))) (\pi_r (c(s))) = (\pi_l (c(s)), \pi_r (c(s))) = c (s).\]
 	
 	\item For each function $f:X\to S \to Y \times S$, we have to show $f^{*}(\eta_X(x)) = f(x)$ for all $x \in X$. For each $s : S$ we have: 
-	$$ f^* (\eta_X (x)) (s) = f^* (\lambda s: S, (x,s)) (s) = f (\pi_l (x,s)) (\pi_r (x,s)) = f (x)(s) $$
+	\[ f^* (\eta_X (x)) (s) = f^* (\lambda s: S, (x,s)) (s) = f (\pi_l (x,s)) (\pi_r (x,s)) = f (x)(s). \]
 	
 	\item Let $f:X\to S \to Y \times S$ and $g:Y\to S \to Z \times S$ be functions, we have to show for each $c : S \to X \times S$:
 	\[

--- a/tex/solutions.tex
+++ b/tex/solutions.tex
@@ -809,7 +809,7 @@ g^{*}(f^{*}(z)) = g^{*}(f^{*}(i_l^X(e))) = g^{*}(i_l^Y(e)) = i_l^Z(e) = (\co{f}{
 	& = (\lambda s : S, (g^* \circ f) (\pi_l (c(s))) (\pi_r (c(s)))),
 	\end{align*}
 	and from the right hand side we have:
-	$$ (g^* \circ f)^* (c) = (\lambda s : S, (g^* \circ f) (\pi_l (c(s))) (\pi_r (c(s)))).$$ 
+	\[ (g^* \circ f)^* (c) = (\lambda s : S, (g^* \circ f) (\pi_l (c(s))) (\pi_r (c(s)))).\]
 	Hence, the left and right hand sides are equal. 
 	\end{enumerate}
 	\end{solution}


### PR DESCRIPTION
1. Added monad of side-effects exercise and solution.
2. Changed `f : X \to Y` to `f : X \to TY` in the proof of the second property of all the existing monad solutions. 
3. Fixed some other typos, punctuation and line alignments in the solutions of monads. 
4. Changed the label of the exception monad exercise to match the content of the exercise.
5. Fixed a typo in the definition of the category of Kleisli triples.
6. Rephrased a part of the solution of `sol:kleisli_triple_familiesofelements`.